### PR TITLE
Created Leap Year Program

### DIFF
--- a/Leap_Year.cpp
+++ b/Leap_Year.cpp
@@ -1,0 +1,9 @@
+#include<bits/stdc++.h>
+using namespace std;
+int main(){
+    int n=2020;
+    if(n%100!=0 && n%4==0 || n%400==0){
+        cout<<n<<" ";
+    }
+    return 0;
+}


### PR DESCRIPTION
To be a leap year, the year number must be divisible by four – except for end-of-century years, which must be divisible by 400. This means that the year 2000 was a leap year, although 1900 was not. 

2020, 2024 and 2028 are all leap years